### PR TITLE
fix camera preview always shows on DSI panel

### DIFF
--- a/CameraHal/testApp/drmDsp.c
+++ b/CameraHal/testApp/drmDsp.c
@@ -60,6 +60,13 @@ int initDrmDsp(int crtcId)
 			break;
 		}
 	}
+
+	if (i != crtcId && crtcId >= 0 && crtcId < pDrmDsp->dev->num_connectors) {
+		if (pDrmDsp->dev->connectors[crtcId]->connection == DRM_MODE_CONNECTED) {
+			i = crtcId;
+		}
+	}
+
 	if (i == pDrmDsp->dev->num_connectors) {
 		printf("no connected connector!\n");
 		return -1;


### PR DESCRIPTION
alter display ID if specified display type is connected